### PR TITLE
Update docker-compose.yml for the workaround

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: always
+    command: --check-caps false
     ports: 
       - 55036:1972
       - 55037:52773


### PR DESCRIPTION
Make IRIS docker images compatible with the latest docker versions.
See more [here(https://community.intersystems.com/post/using-intersystems-iris-containers-docker-201014)